### PR TITLE
Reformatted code block in markdown

### DIFF
--- a/NAMING_STANDARDS.md
+++ b/NAMING_STANDARDS.md
@@ -12,18 +12,20 @@ The same bucket can be used for all state files, so there is no need for **dev**
 
 ## Example:
 An S3 bucket for the website in the dev environment could be named:
+
 hcw-website-bucket-dev-87332
 
 # Repository Folder Structure
 Given that terraform configurations will exist for multiple configurations and environments, create a separate folder for each configuration and environment. Place a descriptive name followed by either the **dev** or **prod** environments. 
 
 A suitable name for the folder containing the CI pipeline for the Prod environment could be:
+
 CI_pipeline_prod
 
 # Terraform Remote state with distinct state files
 The same bucket can be used for multiple state files, by specififying the desired S3 key in each configuration like so:
 
-'''
+~~~
 terraform {
   backend "s3" {
     bucket = "hcw-terraform-state-82734"
@@ -33,6 +35,6 @@ terraform {
     region = "us-east-1"
   }
 }
-'''
+~~~
 
 In the above example, a similar naming convention has been used for the bucket key, with the exception of the project name, since that will be present in the bucket name itself. 


### PR DESCRIPTION
The code block was not formatted in the NAMING_STANDARDS file. Fixed it. @jo016wh @joey1089 
