### PR TITLE
CodeBuild webhook now applies event triggers to only the branch speci…

### DIFF
--- a/CI_Pipeline_Dev/main.tf
+++ b/CI_Pipeline_Dev/main.tf
@@ -230,11 +230,19 @@ resource "aws_codebuild_webhook" "webhook" {
       type    = "EVENT"
       pattern = "PULL_REQUEST_UPDATED"
     }
+    filter {
+      type    = "BASE_REF"
+      pattern = "refs/heads/${var.github_branch}"
+    }
   }
   filter_group {
     filter {
       type    = "EVENT"
       pattern = "PULL_REQUEST_REOPENED"
+    }
+    filter {
+      type    = "BASE_REF"
+      pattern = "refs/heads/${var.github_branch}"
     }
   }
 }


### PR DESCRIPTION
CodeBuild webhook now applies event triggers only to the branch specified by var.github_branch