### PR TITLE
Updated CloudFront configuration to use data blocks for retrieval of …

### DIFF
--- a/Cloudfront_Dev/.terraform.lock.hcl
+++ b/Cloudfront_Dev/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.0"
   hashes = [
     "h1:6qJfvyWObjLPoUrEC8kNVAJ1ZFFrIgzC1xprMkkoSjo=",
+    "h1:CQeYyWigNz838zjXKYH9VDkpjqlGB0phcM742YXiNh4=",
     "zh:00f40a3d9593476693a7a72d993fd289f7be374fe3f2799776c6296eb6ff890a",
     "zh:1010a9fbf55852a8da3473de4ec0f1fcf29efa85d66f61cbe2b086dbbd7747ae",
     "zh:103a5674d1eb1cff05fe35e9baa9875afd18d740868b63f9c0c25eadb5eb4eb7",

--- a/Cloudfront_Dev/main.tf
+++ b/Cloudfront_Dev/main.tf
@@ -1,100 +1,100 @@
-# Define an S3 bucket for hosting the static website
-resource "aws_s3_bucket" "hosting_bucket" {
-  bucket = var.bucket_name # Set the bucket name from a variable
+# # Define an S3 bucket for hosting the static website
+# resource "aws_s3_bucket" "hosting_bucket" {
+#   bucket = var.bucket_name # Set the bucket name from a variable
 
-  tags = {
-    Name        = "Northwest website Dev" # Descriptive name for the bucket
-    Environment = "Dev"                   # Environment tag to denote development stage
-  }
-}
+#   tags = {
+#     Name        = "Northwest website Dev" # Descriptive name for the bucket
+#     Environment = "Dev"                   # Environment tag to denote development stage
+#   }
+# }
 
-# Configure the S3 bucket to serve a static website
-resource "aws_s3_bucket_website_configuration" "hosting_bucket_configuration" {
-  bucket = aws_s3_bucket.hosting_bucket.id # Reference to the hosting bucket
+# # Configure the S3 bucket to serve a static website
+# resource "aws_s3_bucket_website_configuration" "hosting_bucket_configuration" {
+#   bucket = aws_s3_bucket.hosting_bucket.id # Reference to the hosting bucket
 
-  index_document {
-    suffix = "index.html" # Default document served by the website
-  }
+#   index_document {
+#     suffix = "index.html" # Default document served by the website
+#   }
 
-  error_document {
-    key = "error.html" # Document served in case of an error
-  }
-}
+#   error_document {
+#     key = "error.html" # Document served in case of an error
+#   }
+# }
 
-# Enable versioning for the hosting bucket to keep a history of objects
-resource "aws_s3_bucket_versioning" "hosting_bucket_versioning" {
-  bucket = aws_s3_bucket.hosting_bucket.id
-  versioning_configuration {
-    status = "Enabled" # Enable versioning
-  }
-}
+# # Enable versioning for the hosting bucket to keep a history of objects
+# resource "aws_s3_bucket_versioning" "hosting_bucket_versioning" {
+#   bucket = aws_s3_bucket.hosting_bucket.id
+#   versioning_configuration {
+#     status = "Enabled" # Enable versioning
+#   }
+# }
 
-# Configure public access settings for the hosting bucket
-resource "aws_s3_bucket_public_access_block" "hosting_bucket_block" {
-  bucket = aws_s3_bucket.hosting_bucket.id
+# # Configure public access settings for the hosting bucket
+# resource "aws_s3_bucket_public_access_block" "hosting_bucket_block" {
+#   bucket = aws_s3_bucket.hosting_bucket.id
 
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false # These settings are configured to allow public access
-}
+#   block_public_acls       = false
+#   block_public_policy     = false
+#   ignore_public_acls      = false
+#   restrict_public_buckets = false # These settings are configured to allow public access
+# }
 
-# Set the access control list (ACL) for the hosting bucket to public-read
-resource "aws_s3_bucket_acl" "hosting_bucket_acl" {
-  depends_on = [
-    aws_s3_bucket_ownership_controls.hosting_bucket_controls,
-    aws_s3_bucket_public_access_block.hosting_bucket_block,
-  ]
+# # Set the access control list (ACL) for the hosting bucket to public-read
+# resource "aws_s3_bucket_acl" "hosting_bucket_acl" {
+#   depends_on = [
+#     aws_s3_bucket_ownership_controls.hosting_bucket_controls,
+#     aws_s3_bucket_public_access_block.hosting_bucket_block,
+#   ]
 
-  bucket = aws_s3_bucket.hosting_bucket.id
-  acl    = "private"
-}
+#   bucket = aws_s3_bucket.hosting_bucket.id
+#   acl    = "private"
+# }
 
-# Define ownership controls for the hosting bucket
-resource "aws_s3_bucket_ownership_controls" "hosting_bucket_controls" {
-  bucket = aws_s3_bucket.hosting_bucket.id
+# # Define ownership controls for the hosting bucket
+# resource "aws_s3_bucket_ownership_controls" "hosting_bucket_controls" {
+#   bucket = aws_s3_bucket.hosting_bucket.id
 
-  rule {
-    object_ownership = "BucketOwnerPreferred" # Set preferred ownership of objects
-  }
-}
+#   rule {
+#     object_ownership = "BucketOwnerPreferred" # Set preferred ownership of objects
+#   }
+# }
 
-# Define a bucket policy to allow public access to the website files
-resource "aws_s3_bucket_policy" "hosting_bucket_policy" {
-  bucket = aws_s3_bucket.hosting_bucket.id
+# # Define a bucket policy to allow public access to the website files
+# resource "aws_s3_bucket_policy" "hosting_bucket_policy" {
+#   bucket = aws_s3_bucket.hosting_bucket.id
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect    = "Allow"
-        Principal = "*"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject" # To upload the index.html file to the bucket
-        ]
-        Resource = [
-          "${aws_s3_bucket.hosting_bucket.arn}/*"
-        ]
-      }
-    ]
-  })
-}
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [
+#       {
+#         Effect    = "Allow"
+#         Principal = "*"
+#         Action = [
+#           "s3:GetObject",
+#           "s3:PutObject" # To upload the index.html file to the bucket
+#         ]
+#         Resource = [
+#           "${aws_s3_bucket.hosting_bucket.arn}/*"
+#         ]
+#       }
+#     ]
+#   })
+# }
 
-# Output the URL of the hosted static website
-output "website_url" {
-  value = "http://${aws_s3_bucket.hosting_bucket.bucket}.s3-website-${var.aws_region}.amazonaws.com"
-}
+# # Output the URL of the hosted static website
+# output "website_url" {
+#   value = "http://${aws_s3_bucket.hosting_bucket.bucket}.s3-website-${var.aws_region}.amazonaws.com"
+# }
 
-# Upload a file to the hosting bucket - static website html file
-# remove this block if not needed any more
-resource "aws_s3_object" "hcw-website-bucket-prod-2024-cftest" {
-  bucket = var.bucket_name
-  key    = "index.html" #name on the s3 bucket
-  source = "../index.html"
+# # Upload a file to the hosting bucket - static website html file
+# # remove this block if not needed any more
+# resource "aws_s3_object" "hcw-website-bucket-prod-2024-cftest" {
+#   bucket = var.bucket_name
+#   key    = "index.html" #name on the s3 bucket
+#   source = "../index.html"
 
-  # The filemd5() function is available in Terraform 0.11.12 and later
-  # For Terraform 0.11.11 and earlier, use the md5() function and the file() function:
-  # etag = "${md5(file("path/to/file"))}"
-  etag = filemd5("../index.html")
-}
+#   # The filemd5() function is available in Terraform 0.11.12 and later
+#   # For Terraform 0.11.11 and earlier, use the md5() function and the file() function:
+#   # etag = "${md5(file("path/to/file"))}"
+#   etag = filemd5("../index.html")
+# }

--- a/Cloudfront_Dev/providers.tf
+++ b/Cloudfront_Dev/providers.tf
@@ -1,5 +1,6 @@
 # modified to run with cloudfront code - note backend doesn't allow variables only direct values.
 terraform {
+  required_version = "~> 1.7.0"
   backend "s3" {
     bucket         = "hcw-terraform-state-87364"
     encrypt        = true

--- a/Cloudfront_Dev/variables.tf
+++ b/Cloudfront_Dev/variables.tf
@@ -14,16 +14,3 @@ variable "aws_profile" {
   description = "Name of the AWS Profile being used"
   type        = string
 }
-
-variable "aws_access_key_id" {
-  description = "Access key"
-  type        = string
-  sensitive   = true
-}
-
-variable "aws_secret_access_key" {
-  description = "Secret Access Key"
-  type        = string
-  sensitive   = true
-}
-


### PR DESCRIPTION
@joey1089 I just cleaned up your configuration a little bit. You didn't need to provision the S3 bucket again. I just added a data block to reference it. You were definitely on the right track, I think just overcomplicating things a little bit. 

I kept the main.tf file and just commented everything out. Now there is also an output block that outputs the cloudfront url. The prod website is accessible from this url since I manually uploaded an index file there for testing. Go ahead and check the configuration locally before you merge, but from what I can see this works. 

Oh, and I also removed the variables for access key id and secret access key. You don't need them if you're using a profile. Just more stuff to enter in. 