### PR TITLE
Updated file path to buildspec. Filter stage should work now

### DIFF
--- a/CI_Pipeline/main.tf
+++ b/CI_Pipeline/main.tf
@@ -290,7 +290,7 @@ resource "aws_codebuild_project" "filter" {
   }
   source {
     type                = "CODEPIPELINE"
-    buildspec           = "CI_Pipeline_Dev/files/filter_buildspec.yml"
+    buildspec           = "CI_Pipeline/files/filter_buildspec.yml"
   }
   artifacts {
     type = "CODEPIPELINE"


### PR DESCRIPTION
When I changed the CI folder to CI_Pipeline I forgot to update one of the paths to the buildspec file in the filter stage. Fixed this now, and the filter stage should work. 

