### PR TITLE
Added files to invalidate CloudFront cache

### DIFF
--- a/CI_Pipeline/files/invalidate_cache.py
+++ b/CI_Pipeline/files/invalidate_cache.py
@@ -1,0 +1,19 @@
+import boto3
+from datetime import datetime
+
+cloudfront = boto3.client("cloudfront")
+bucket_key = "index.html"
+distribution_id = "E2D4ZRI8IRCEPK"
+
+cloudfront.create_invalidation(
+    DistributionId= distribution_id,
+    InvalidationBatch= {
+        'Paths': {
+            'Quantity': 1,
+            'Items': [
+                f"/{bucket_key}",
+            ]
+        },
+        'CallerReference': str(datetime.timestamp(datetime.now()))
+    }
+)

--- a/CI_Pipeline/files/invalidate_cache_buildspec.yml
+++ b/CI_Pipeline/files/invalidate_cache_buildspec.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - yum update
+    - wget https://www.python.org/ftp/python/3.11.7/Python-3.11.7.tar.xz
+    - tar -xf Python-3.11.7.tar.xz
+    - cd Python-3.11.7
+    - ./configure
+    - make
+    - make install
+    - pip3 install boto3
+  
+  build:
+    - python3 CI_Pipeline/files/invalidate_cache.py

--- a/CI_Pipeline/main.tf
+++ b/CI_Pipeline/main.tf
@@ -333,8 +333,7 @@ resource "aws_codebuild_project" "invalidate" {
     buildspec           = "CI_Pipeline/files/invalidate_cache_buildspec.yml"
   }
   artifacts {
-    type = "NO_ARTIFACTS"
-    name = null
+    type = "CODEPIPELINE"
   }
   cache {
     type = "NO_CACHE"

--- a/CI_Pipeline/main.tf
+++ b/CI_Pipeline/main.tf
@@ -197,6 +197,22 @@ resource "aws_codepipeline" "pipeline" {
       }
     }
   }
+  stage{
+    name = "Invalidate_CloudFront"
+
+    action {
+      name = "Invalidate_CloudFront"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["source_output"]
+      version = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.invalidate.name
+      }
+    }
+  }
 }
 
 ############################################
@@ -295,6 +311,30 @@ resource "aws_codebuild_project" "filter" {
   artifacts {
     type = "CODEPIPELINE"
 
+  }
+  cache {
+    type = "NO_CACHE"
+  }
+}
+
+resource "aws_codebuild_project" "invalidate" {
+  name          = "${var.project}-invalidate-build-step-${var.environment}"
+  description   = "Invalidate CloudFront"
+  service_role  = var.codebuild_role
+  build_timeout = "5"
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+  }
+  source {
+    type                = "CODEPIPELINE"
+    buildspec           = "CI_Pipeline/files/invalidate_cache_buildspec.yml"
+  }
+  artifacts {
+    type = "NO_ARTIFACTS"
+    name = null
   }
   cache {
     type = "NO_CACHE"

--- a/CloudFront/main.tf
+++ b/CloudFront/main.tf
@@ -115,3 +115,7 @@ resource "aws_cloudfront_distribution" "s3_cf_distribution" {
 output "cloudfront_distribution_url" {
   value = aws_cloudfront_distribution.s3_cf_distribution.domain_name
 }
+
+output "cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.s3_cf_distribution.id
+}


### PR DESCRIPTION
I don't believe this is a requirement of the project, but I added another step that invalidates the CloudFront cache (so that the CloudFront distribution updates to cache the new content) after deploy to Production. 

I don't really have time to properly test it out in the development environment, so if doesn't work we can just revert the pull request. 

It'd be cool if it does though. 

@jo016wh @joey1089 